### PR TITLE
path.existsSync is now fs.existSync

### DIFF
--- a/validator.js
+++ b/validator.js
@@ -8,7 +8,7 @@ var underscore = require("underscore")
 var werckerBoxSchema = JSON.parse(fs.readFileSync(path.join(__dirname, 'wercker-step-schema.json')).toString())
 
 exports.validate = function (filename, callback) {
-  if(!path.existsSync(filename)){
+  if(!fs.existsSync(filename)){
     return callback("File " + filename + " does not exist.")
   }
 


### PR DESCRIPTION
`validate-wercker-step` failed because node moved `path.existsSync` to the `fs` module:

```
source "/pipeline/validate-wercker-step-add22868-3bc3-4618-9cde-17aae417e4e2/run.sh" < /dev/null
Validating /pipeline/source/wercker-step.yml
/pipeline/validate-wercker-step-add22868-3bc3-4618-9cde-17aae417e4e2/validator.js:11
  if(!path.existsSync(filename)){
           ^

TypeError: path.existsSync is not a function
    at Object.exports.validate (/pipeline/validate-wercker-step-add22868-3bc3-4618-9cde-17aae417e4e2/validator.js:11:12)
    at Object.<anonymous> (/pipeline/validate-wercker-step-add22868-3bc3-4618-9cde-17aae417e4e2/run.js:11:11)
    at Module._compile (module.js:398:26)
    at Object.Module._extensions..js (module.js:405:10)
    at Module.load (module.js:344:32)
    at Function.Module._load (module.js:301:12)
    at Function.Module.runMain (module.js:430:10)
    at startup (node.js:141:18)
    at node.js:980:3
```

This should not happen any more with this fix!